### PR TITLE
Incorporate Selectable Targets and Launcher Speeds

### DIFF
--- a/Small_Robot/src/main/java/frc/robot/Robot.java
+++ b/Small_Robot/src/main/java/frc/robot/Robot.java
@@ -28,8 +28,8 @@ public class Robot extends TimedRobot {
   public void robotInit() {
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
-    SmartDashboard.putString("Software Version:", "Small_Robot V1.0");
-    System.out.println("Software Version: Small_Robot V1.0");
+    SmartDashboard.putString("Software Version:", "selectable_targets V1.0 build 1 - Verified Operational");
+    System.out.println("Software Version: selectable_targets V1.0 build 1 - Verified Operational");
     m_robotContainer = new RobotContainer();
   }
 

--- a/Small_Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Small_Robot/src/main/java/frc/robot/RobotContainer.java
@@ -66,29 +66,39 @@ public class RobotContainer {
     //     .onTrue(new GoToTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
 
     m_driverController
-        .a()
+        .y()
         // .onTrue(new GoToTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
         .onTrue(new GoToSpecificTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
 
     m_driverController
         .rightBumper()
-        .onTrue(Commands.run(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
+        .onTrue(
+            Commands.runOnce(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
     m_driverController
         .leftBumper()
-        .onTrue(Commands.run(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
+        .onTrue(
+            Commands.runOnce(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
 
     m_driverController
         .povUp()
         .onTrue(
-            Commands.run(() -> m_launcherSubsystem.increaseLauncherSpeed(), m_launcherSubsystem));
+            Commands.runOnce(
+                () -> m_launcherSubsystem.increaseLauncherSpeed(), m_launcherSubsystem));
     m_driverController
         .povDown()
         .onTrue(
-            Commands.run(() -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
+            Commands.runOnce(
+                () -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
 
     // Schedule `exampleMethodCommand` when the Xbox controller's B button is pressed,
     // cancelling on release.
-    m_driverController.b().whileTrue(m_launcherSubsystem.spoolUpLauncherCommand());
+    m_driverController
+        .a()
+        .onTrue(Commands.runOnce(() -> m_launcherSubsystem.spoolUpLauncher(), m_launcherSubsystem));
+
+    m_driverController
+        .b()
+        .onTrue(Commands.runOnce(() -> m_launcherSubsystem.stop(), m_launcherSubsystem));
   }
 
   /**

--- a/Small_Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Small_Robot/src/main/java/frc/robot/RobotContainer.java
@@ -70,6 +70,22 @@ public class RobotContainer {
         // .onTrue(new GoToTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
         .onTrue(new GoToSpecificTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
 
+    m_driverController
+        .rightBumper()
+        .onTrue(Commands.run(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
+    m_driverController
+        .leftBumper()
+        .onTrue(Commands.run(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
+
+    m_driverController
+        .povUp()
+        .onTrue(
+            Commands.run(() -> m_launcherSubsystem.increaseLauncherSpeed(), m_launcherSubsystem));
+    m_driverController
+        .povDown()
+        .onTrue(
+            Commands.run(() -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
+
     // Schedule `exampleMethodCommand` when the Xbox controller's B button is pressed,
     // cancelling on release.
     m_driverController.b().whileTrue(m_launcherSubsystem.spoolUpLauncherCommand());

--- a/Small_Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Small_Robot/src/main/java/frc/robot/RobotContainer.java
@@ -80,22 +80,15 @@ public class RobotContainer {
     m_driverController
         .povUp()
         .onTrue(
-            Commands.runOnce(
-                () -> m_launcherSubsystem.increaseLauncherSpeed(), m_launcherSubsystem));
+            Commands.run(() -> m_launcherSubsystem.increaseLauncherSpeed(), m_launcherSubsystem));
     m_driverController
         .povDown()
         .onTrue(
-            Commands.runOnce(
-                () -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
+            Commands.run(() -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
 
     // Schedule `exampleMethodCommand` when the Xbox controller's B button is pressed,
     // cancelling on release.
-    m_driverController
-        .b()
-        .onTrue(Commands.runOnce(() -> m_launcherSubsystem.stopLauncher(), m_launcherSubsystem));
-    m_driverController
-        .y()
-        .onTrue(Commands.runOnce(() -> m_launcherSubsystem.spoolUpLauncher(), m_launcherSubsystem));
+    m_driverController.b().whileTrue(m_launcherSubsystem.spoolUpLauncherCommand());
   }
 
   /**

--- a/Small_Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Small_Robot/src/main/java/frc/robot/RobotContainer.java
@@ -80,15 +80,22 @@ public class RobotContainer {
     m_driverController
         .povUp()
         .onTrue(
-            Commands.run(() -> m_launcherSubsystem.increaseLauncherSpeed(), m_launcherSubsystem));
+            Commands.runOnce(
+                () -> m_launcherSubsystem.increaseLauncherSpeed(), m_launcherSubsystem));
     m_driverController
         .povDown()
         .onTrue(
-            Commands.run(() -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
+            Commands.runOnce(
+                () -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
 
     // Schedule `exampleMethodCommand` when the Xbox controller's B button is pressed,
     // cancelling on release.
-    m_driverController.b().whileTrue(m_launcherSubsystem.spoolUpLauncherCommand());
+    m_driverController
+        .b()
+        .onTrue(Commands.runOnce(() -> m_launcherSubsystem.stopLauncher(), m_launcherSubsystem));
+    m_driverController
+        .y()
+        .onTrue(Commands.runOnce(() -> m_launcherSubsystem.spoolUpLauncher(), m_launcherSubsystem));
   }
 
   /**

--- a/Small_Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Small_Robot/src/main/java/frc/robot/RobotContainer.java
@@ -61,18 +61,21 @@ public class RobotContainer {
    * joysticks}.
    */
   private void configureBindings() {
+    // Schedule `ExampleCommand` when `exampleCondition` changes to `true`
+    // new Trigger(m_driverController.a().onTrue(getAutonomousCommand()))
+    //     .onTrue(new GoToTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
+
     m_driverController
-        .x()
+        .a()
+        // .onTrue(new GoToTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
         .onTrue(new GoToSpecificTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
 
     m_driverController
         .rightBumper()
-        .onTrue(
-            Commands.runOnce(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
+        .onTrue(Commands.run(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
     m_driverController
         .leftBumper()
-        .onTrue(
-            Commands.runOnce(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
+        .onTrue(Commands.run(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
 
     m_driverController
         .povUp()
@@ -85,11 +88,13 @@ public class RobotContainer {
             Commands.runOnce(
                 () -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
 
+    // Schedule `exampleMethodCommand` when the Xbox controller's B button is pressed,
+    // cancelling on release.
     m_driverController
         .b()
         .onTrue(Commands.runOnce(() -> m_launcherSubsystem.stopLauncher(), m_launcherSubsystem));
     m_driverController
-        .a()
+        .y()
         .onTrue(Commands.runOnce(() -> m_launcherSubsystem.spoolUpLauncher(), m_launcherSubsystem));
   }
 

--- a/Small_Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Small_Robot/src/main/java/frc/robot/RobotContainer.java
@@ -61,21 +61,16 @@ public class RobotContainer {
    * joysticks}.
    */
   private void configureBindings() {
-    // Schedule `ExampleCommand` when `exampleCondition` changes to `true`
-    // new Trigger(m_driverController.a().onTrue(getAutonomousCommand()))
-    //     .onTrue(new GoToTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
-
     m_driverController
-        .a()
-        // .onTrue(new GoToTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
+        .x()
         .onTrue(new GoToSpecificTargetCommand(m_cameraSubsystem, m_mecanumDriveSubsystem));
 
     m_driverController
         .rightBumper()
-        .onTrue(Commands.run(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
+        .onTrue(Commands.runOnce(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
     m_driverController
         .leftBumper()
-        .onTrue(Commands.run(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
+        .onTrue(Commands.runOnce(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
 
     m_driverController
         .povUp()
@@ -88,13 +83,11 @@ public class RobotContainer {
             Commands.runOnce(
                 () -> m_launcherSubsystem.decreaseLauncherSpeed(), m_launcherSubsystem));
 
-    // Schedule `exampleMethodCommand` when the Xbox controller's B button is pressed,
-    // cancelling on release.
     m_driverController
         .b()
         .onTrue(Commands.runOnce(() -> m_launcherSubsystem.stopLauncher(), m_launcherSubsystem));
     m_driverController
-        .y()
+        .a()
         .onTrue(Commands.runOnce(() -> m_launcherSubsystem.spoolUpLauncher(), m_launcherSubsystem));
   }
 

--- a/Small_Robot/src/main/java/frc/robot/RobotContainer.java
+++ b/Small_Robot/src/main/java/frc/robot/RobotContainer.java
@@ -67,10 +67,12 @@ public class RobotContainer {
 
     m_driverController
         .rightBumper()
-        .onTrue(Commands.runOnce(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
+        .onTrue(
+            Commands.runOnce(() -> m_cameraSubsystem.incrementDesiredTarget(), m_cameraSubsystem));
     m_driverController
         .leftBumper()
-        .onTrue(Commands.runOnce(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
+        .onTrue(
+            Commands.runOnce(() -> m_cameraSubsystem.decrementDesiredTarget(), m_cameraSubsystem));
 
     m_driverController
         .povUp()

--- a/Small_Robot/src/main/java/frc/robot/commands/GoToSpecificTargetCommand.java
+++ b/Small_Robot/src/main/java/frc/robot/commands/GoToSpecificTargetCommand.java
@@ -68,7 +68,7 @@ public class GoToSpecificTargetCommand extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    if (timer.get() > 10.0) {
+    if (timer.get() > 10.0 && !m_CameraSubsystem.getValidTarget()) {
       return true;
     }
     return false;

--- a/Small_Robot/src/main/java/frc/robot/commands/GoToSpecificTargetCommand.java
+++ b/Small_Robot/src/main/java/frc/robot/commands/GoToSpecificTargetCommand.java
@@ -47,7 +47,8 @@ public class GoToSpecificTargetCommand extends CommandBase {
   @Override
   public void execute() {
     // Add timer
-    if (m_CameraSubsystem.getValidTarget() && m_CameraSubsystem.getTargetID() == 3.0) {
+    if (m_CameraSubsystem.getValidTarget()
+        && m_CameraSubsystem.getTargetID() == m_CameraSubsystem.getDesiredTarget()) {
       if (m_CameraSubsystem.getDistance() > distanceLimit) {
         m_DriveSubsystem.driveForwards(forwardSpeed);
       } else {

--- a/Small_Robot/src/main/java/frc/robot/commands/GoToSpecificTargetCommand.java
+++ b/Small_Robot/src/main/java/frc/robot/commands/GoToSpecificTargetCommand.java
@@ -68,7 +68,7 @@ public class GoToSpecificTargetCommand extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    if (timer.get() > 10.0 && !m_CameraSubsystem.getValidTarget()) {
+    if (timer.get() > 10.0) {
       return true;
     }
     return false;

--- a/Small_Robot/src/main/java/frc/robot/subsystems/CameraSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/CameraSubsystem.java
@@ -17,6 +17,8 @@ public class CameraSubsystem extends SubsystemBase {
   private double angleBetweenCameraAndTarget;
   private double distanceFromTarget;
 
+  private double desiredTarget;
+
   public CameraSubsystem(String limelightName) {
     this.limelightName = limelightName;
     LimelightHelpers.setLEDMode_ForceOff(limelightName);
@@ -26,6 +28,28 @@ public class CameraSubsystem extends SubsystemBase {
     heightOfCamera = 8;
     heightOfTarget = 16;
     angleBetweenLevelPlaneAndCamera = 10;
+
+    desiredTarget = 1.0;
+  }
+
+  public void incrementDesiredTarget() {
+    if (desiredTarget < 3.0) {
+      desiredTarget += 1.0;
+    } else {
+      desiredTarget = 1.0;
+    }
+  }
+
+  public void decrementDesiredTarget() {
+    if (desiredTarget > 1.0) {
+      desiredTarget -= 1.0;
+    } else {
+      desiredTarget = 3.0;
+    }
+  }
+
+  public double getDesiredTarget() {
+    return desiredTarget;
   }
 
   public LimelightResults getLatestResults() {
@@ -93,6 +117,7 @@ public class CameraSubsystem extends SubsystemBase {
     SmartDashboard.putNumber(
         "AngleBetween Level Plane and Camera:", angleBetweenLevelPlaneAndCamera);
     SmartDashboard.putNumber("Distance from Target:", distanceFromTarget);
+    SmartDashboard.putNumber("Desired Target:", desiredTarget);
 
     if (data.tv) {
       SmartDashboard.putBoolean("Valid Target Found:", data.tv);

--- a/Small_Robot/src/main/java/frc/robot/subsystems/CameraSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/CameraSubsystem.java
@@ -68,7 +68,6 @@ public class CameraSubsystem extends SubsystemBase {
       double ty = fiducial.ty;
       double ta = fiducial.ta;
       double tid = fiducial.fiducialID;
-      // double ts = fiducial.ts;
       boolean tv = fiducial.fiducialID != 0; // Assuming ID 0 means no valid target
       Pose2d pose2d = fiducial.getRobotPose_TargetSpace2D();
 

--- a/Small_Robot/src/main/java/frc/robot/subsystems/CameraSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/CameraSubsystem.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems;
 
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.LimelightHelpers;
 import frc.robot.LimelightHelpers.LimelightResults;
@@ -106,37 +105,37 @@ public class CameraSubsystem extends SubsystemBase {
 
   @Override
   public void periodic() {
-    /* Calculate distance from target */
-    calculateDistanceFromTarget();
-    /* Get Target Data */
-    TargetData data = getTargetData();
+    // /* Calculate distance from target */
+    // calculateDistanceFromTarget();
+    // /* Get Target Data */
+    // TargetData data = getTargetData();
 
-    /* Update Dashboard */
-    SmartDashboard.putNumber("Height of Camera:", heightOfCamera);
-    SmartDashboard.putNumber("Height of Target:", heightOfTarget);
-    SmartDashboard.putNumber(
-        "AngleBetween Level Plane and Camera:", angleBetweenLevelPlaneAndCamera);
-    SmartDashboard.putNumber("Distance from Target:", distanceFromTarget);
-    SmartDashboard.putNumber("Desired Target:", desiredTarget);
+    // /* Update Dashboard */
+    // SmartDashboard.putNumber("Height of Camera:", heightOfCamera);
+    // SmartDashboard.putNumber("Height of Target:", heightOfTarget);
+    // SmartDashboard.putNumber(
+    //     "AngleBetween Level Plane and Camera:", angleBetweenLevelPlaneAndCamera);
+    // SmartDashboard.putNumber("Distance from Target:", distanceFromTarget);
+    // SmartDashboard.putNumber("Desired Target:", desiredTarget);
 
-    if (data.tv) {
-      SmartDashboard.putBoolean("Valid Target Found:", data.tv);
-      SmartDashboard.putNumber("Limelight X Value:", data.tx);
-      SmartDashboard.putNumber("Limelight Y Value:", data.ty);
-      SmartDashboard.putNumber("Limelight Area Value:", data.ta);
-      SmartDashboard.putNumber("Target ID:", data.tid);
-      SmartDashboard.putNumber("2d Pose X:", data.pose2d.getX());
-      SmartDashboard.putNumber("2d Pose Y:", data.pose2d.getY());
-      SmartDashboard.putNumber("2d Pose Rotation:", data.pose2d.getRotation().getDegrees());
-    } else {
-      SmartDashboard.putBoolean("Valid Target Found:", data.tv);
-      SmartDashboard.putNumber("Limelight X Value:", 0);
-      SmartDashboard.putNumber("Limelight Y Value:", 0);
-      SmartDashboard.putNumber("Limelight Area Value:", 0);
-      SmartDashboard.putNumber("Target ID:", 0);
-      SmartDashboard.putNumber("2d Pose X:", 0);
-      SmartDashboard.putNumber("2d Pose Y:", 0);
-      SmartDashboard.putNumber("2d Pose Rotation:", 0);
-    }
+    // if (data.tv) {
+    //   SmartDashboard.putBoolean("Valid Target Found:", data.tv);
+    //   SmartDashboard.putNumber("Limelight X Value:", data.tx);
+    //   SmartDashboard.putNumber("Limelight Y Value:", data.ty);
+    //   SmartDashboard.putNumber("Limelight Area Value:", data.ta);
+    //   SmartDashboard.putNumber("Target ID:", data.tid);
+    //   SmartDashboard.putNumber("2d Pose X:", data.pose2d.getX());
+    //   SmartDashboard.putNumber("2d Pose Y:", data.pose2d.getY());
+    //   SmartDashboard.putNumber("2d Pose Rotation:", data.pose2d.getRotation().getDegrees());
+    // } else {
+    //   SmartDashboard.putBoolean("Valid Target Found:", data.tv);
+    //   SmartDashboard.putNumber("Limelight X Value:", 0);
+    //   SmartDashboard.putNumber("Limelight Y Value:", 0);
+    //   SmartDashboard.putNumber("Limelight Area Value:", 0);
+    //   SmartDashboard.putNumber("Target ID:", 0);
+    //   SmartDashboard.putNumber("2d Pose X:", 0);
+    //   SmartDashboard.putNumber("2d Pose Y:", 0);
+    //   SmartDashboard.putNumber("2d Pose Rotation:", 0);
+    // }
   }
 }

--- a/Small_Robot/src/main/java/frc/robot/subsystems/CameraSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/CameraSubsystem.java
@@ -68,6 +68,7 @@ public class CameraSubsystem extends SubsystemBase {
       double ty = fiducial.ty;
       double ta = fiducial.ta;
       double tid = fiducial.fiducialID;
+      // double ts = fiducial.ts;
       boolean tv = fiducial.fiducialID != 0; // Assuming ID 0 means no valid target
       Pose2d pose2d = fiducial.getRobotPose_TargetSpace2D();
 

--- a/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
@@ -20,16 +20,16 @@ public class LauncherSubsystem extends SubsystemBase {
 
     timer = new Timer();
 
-    /* 
-     * This initial launcher speed is lower than what we think we'll need, 
-     * but we'll be able to use the controller to increase or decrease it 
+    /*
+     * This initial launcher speed is lower than what we think we'll need,
+     * but we'll be able to use the controller to increase or decrease it
      * as necessary.
      */
     launcherSpeed = 0.50;
   }
 
   public void spoolUpLauncher() {
-    /* 
+    /*
      * Ensure that the launcher is stopped before assuming anything about speed.
      */
     stopLauncher();
@@ -39,7 +39,7 @@ public class LauncherSubsystem extends SubsystemBase {
 
     while (currentSpeed < launcherSpeed) {
       timer.start();
-      while (timer.get() < 0.2) {
+      while (timer.get() < 0.1) {
         // wait
       }
       currentSpeed += 0.1;

--- a/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
@@ -1,8 +1,8 @@
 package frc.robot.subsystems;
 
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class LauncherSubsystem extends SubsystemBase {
@@ -13,64 +13,38 @@ public class LauncherSubsystem extends SubsystemBase {
   private double launcherSpeed;
 
   public LauncherSubsystem() {
-    leftMotor = new PWMSparkMax(4);
-    rightMotor = new PWMSparkMax(5);
+    leftMotor = new PWMSparkMax(5);
+    rightMotor = new PWMSparkMax(6);
 
-    leftMotor.setInverted(true);
+    rightMotor.setInverted(true);
 
-    launcherSpeed = 0.80;
+    launcherSpeed = 0.20;
 
     /* commented out because we don't want to spool up the launcher on initialization */
     // leftMotor.set(launcherSpeed);
     // rightMotor.set(launcherSpeed);
   }
 
-  public void spoolUpLauncher() {
+  public CommandBase spoolUpLauncherCommand() {
     // Inline construction of command goes here.
     // Subsystem::RunOnce implicitly requires `this` subsystem.
-    // return runOnce(
-    //     () -> {
-    //       /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the
-    // operator spool up the launcher */
-    //       //   leftMotor.set(launcherSpeed);
-    //       //   rightMotor.set(launcherSpeed);
-    //     });
-    Timer timer = new Timer();
-    timer.reset();
-    stopLauncher();
-    double currentSpeed = 0.0;
-
-    while (currentSpeed < launcherSpeed) {
-      timer.start();
-      while (timer.get() < 0.1) {
-        // wait
-      }
-      timer.stop();
-      timer.reset();
-      currentSpeed += 0.1;
-      leftMotor.set(currentSpeed);
-      rightMotor.set(currentSpeed);
-    }
-  }
-
-  public void stopLauncher() {
-    leftMotor.stopMotor();
-    rightMotor.stopMotor();
+    return runOnce(
+        () -> {
+          /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the operator spool up the launcher */
+          //   leftMotor.set(launcherSpeed);
+          //   rightMotor.set(launcherSpeed);
+        });
   }
 
   public void increaseLauncherSpeed() {
     if (launcherSpeed < 1.0) {
       launcherSpeed += 0.1;
-      // leftMotor.set(launcherSpeed);
-      // rightMotor.set(launcherSpeed);
     }
   }
 
   public void decreaseLauncherSpeed() {
     if (launcherSpeed > 0.1) {
       launcherSpeed -= 0.1;
-      // leftMotor.set(launcherSpeed);
-      // rightMotor.set(launcherSpeed);
     }
   }
 

--- a/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
@@ -7,10 +7,10 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class LauncherSubsystem extends SubsystemBase {
 
-  //   private MecanumDrive m_robotDrive;
   private PWMSparkMax leftMotor;
   private PWMSparkMax rightMotor;
   private double launcherSpeed;
+  private Timer timer;
 
   public LauncherSubsystem() {
     leftMotor = new PWMSparkMax(4);
@@ -18,38 +18,36 @@ public class LauncherSubsystem extends SubsystemBase {
 
     rightMotor.setInverted(true);
 
-    launcherSpeed = 0.80;
+    timer = new Timer();
 
-    /* commented out because we don't want to spool up the launcher on initialization */
-    // leftMotor.set(launcherSpeed);
-    // rightMotor.set(launcherSpeed);
+    /* 
+     * This initial launcher speed is lower than what we think we'll need, 
+     * but we'll be able to use the controller to increase or decrease it 
+     * as necessary.
+     */
+    launcherSpeed = 0.50;
   }
 
   public void spoolUpLauncher() {
-    // Inline construction of command goes here.
-    // Subsystem::RunOnce implicitly requires `this` subsystem.
-    // return runOnce(
-    //     () -> {
-    //       /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the
-    // operator spool up the launcher */
-    //       //   leftMotor.set(launcherSpeed);
-    //       //   rightMotor.set(launcherSpeed);
-    //     });
-    Timer timer = new Timer();
-    timer.reset();
+    /* 
+     * Ensure that the launcher is stopped before assuming anything about speed.
+     */
     stopLauncher();
     double currentSpeed = 0.0;
 
+    timer.reset();
+
     while (currentSpeed < launcherSpeed) {
       timer.start();
-      while (timer.get() < 0.1) {
+      while (timer.get() < 0.2) {
         // wait
       }
-      timer.stop();
-      timer.reset();
       currentSpeed += 0.1;
       leftMotor.set(currentSpeed);
       rightMotor.set(currentSpeed);
+
+      timer.stop();
+      timer.reset();
     }
   }
 
@@ -61,16 +59,12 @@ public class LauncherSubsystem extends SubsystemBase {
   public void increaseLauncherSpeed() {
     if (launcherSpeed < 1.0) {
       launcherSpeed += 0.1;
-      // leftMotor.set(launcherSpeed);
-      // rightMotor.set(launcherSpeed);
     }
   }
 
   public void decreaseLauncherSpeed() {
     if (launcherSpeed > 0.1) {
       launcherSpeed -= 0.1;
-      // leftMotor.set(launcherSpeed);
-      // rightMotor.set(launcherSpeed);
     }
   }
 

--- a/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
@@ -12,8 +12,8 @@ public class LauncherSubsystem extends SubsystemBase {
   private double launcherSpeed;
 
   public LauncherSubsystem() {
-    leftMotor = new PWMSparkMax(5);
-    rightMotor = new PWMSparkMax(6);
+    leftMotor = new PWMSparkMax(4);
+    rightMotor = new PWMSparkMax(5);
 
     leftMotor.setInverted(true);
 

--- a/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
@@ -2,7 +2,6 @@ package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class LauncherSubsystem extends SubsystemBase {
@@ -16,7 +15,7 @@ public class LauncherSubsystem extends SubsystemBase {
     leftMotor = new PWMSparkMax(5);
     rightMotor = new PWMSparkMax(6);
 
-    rightMotor.setInverted(true);
+    leftMotor.setInverted(true);
 
     launcherSpeed = 0.20;
 
@@ -25,15 +24,21 @@ public class LauncherSubsystem extends SubsystemBase {
     // rightMotor.set(launcherSpeed);
   }
 
-  public CommandBase spoolUpLauncherCommand() {
-    // Inline construction of command goes here.
-    // Subsystem::RunOnce implicitly requires `this` subsystem.
-    return runOnce(
-        () -> {
-          /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the operator spool up the launcher */
-          //   leftMotor.set(launcherSpeed);
-          //   rightMotor.set(launcherSpeed);
-        });
+  // public CommandBase spoolUpLauncherCommand() {
+  //   // Inline construction of command goes here.
+  //   // Subsystem::RunOnce implicitly requires `this` subsystem.
+  //   return runOnce(
+  //       () -> {
+  //         /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the
+  // operator spool up the launcher */
+  //         //   leftMotor.set(launcherSpeed);
+  //         //   rightMotor.set(launcherSpeed);
+  //       });
+  // }
+
+  public void spoolUpLauncher() {
+    leftMotor.set(launcherSpeed);
+    rightMotor.set(launcherSpeed);
   }
 
   public void increaseLauncherSpeed() {

--- a/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
@@ -7,47 +7,49 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class LauncherSubsystem extends SubsystemBase {
 
+  //   private MecanumDrive m_robotDrive;
   private PWMSparkMax leftMotor;
   private PWMSparkMax rightMotor;
   private double launcherSpeed;
-  private Timer timer;
 
   public LauncherSubsystem() {
     leftMotor = new PWMSparkMax(4);
     rightMotor = new PWMSparkMax(5);
 
-    rightMotor.setInverted(true);
+    leftMotor.setInverted(true);
 
-    timer = new Timer();
+    launcherSpeed = 0.80;
 
-    /*
-     * This initial launcher speed is lower than what we think we'll need,
-     * but we'll be able to use the controller to increase or decrease it
-     * as necessary.
-     */
-    launcherSpeed = 0.50;
+    /* commented out because we don't want to spool up the launcher on initialization */
+    // leftMotor.set(launcherSpeed);
+    // rightMotor.set(launcherSpeed);
   }
 
   public void spoolUpLauncher() {
-    /*
-     * Ensure that the launcher is stopped before assuming anything about speed.
-     */
+    // Inline construction of command goes here.
+    // Subsystem::RunOnce implicitly requires `this` subsystem.
+    // return runOnce(
+    //     () -> {
+    //       /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the
+    // operator spool up the launcher */
+    //       //   leftMotor.set(launcherSpeed);
+    //       //   rightMotor.set(launcherSpeed);
+    //     });
+    Timer timer = new Timer();
+    timer.reset();
     stopLauncher();
     double currentSpeed = 0.0;
-
-    timer.reset();
 
     while (currentSpeed < launcherSpeed) {
       timer.start();
       while (timer.get() < 0.1) {
         // wait
       }
+      timer.stop();
+      timer.reset();
       currentSpeed += 0.1;
       leftMotor.set(currentSpeed);
       rightMotor.set(currentSpeed);
-
-      timer.stop();
-      timer.reset();
     }
   }
 
@@ -59,12 +61,16 @@ public class LauncherSubsystem extends SubsystemBase {
   public void increaseLauncherSpeed() {
     if (launcherSpeed < 1.0) {
       launcherSpeed += 0.1;
+      // leftMotor.set(launcherSpeed);
+      // rightMotor.set(launcherSpeed);
     }
   }
 
   public void decreaseLauncherSpeed() {
     if (launcherSpeed > 0.1) {
       launcherSpeed -= 0.1;
+      // leftMotor.set(launcherSpeed);
+      // rightMotor.set(launcherSpeed);
     }
   }
 

--- a/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
@@ -1,8 +1,8 @@
 package frc.robot.subsystems;
 
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class LauncherSubsystem extends SubsystemBase {
@@ -13,38 +13,64 @@ public class LauncherSubsystem extends SubsystemBase {
   private double launcherSpeed;
 
   public LauncherSubsystem() {
-    leftMotor = new PWMSparkMax(5);
-    rightMotor = new PWMSparkMax(6);
+    leftMotor = new PWMSparkMax(4);
+    rightMotor = new PWMSparkMax(5);
 
     rightMotor.setInverted(true);
 
-    launcherSpeed = 0.20;
+    launcherSpeed = 0.80;
 
     /* commented out because we don't want to spool up the launcher on initialization */
     // leftMotor.set(launcherSpeed);
     // rightMotor.set(launcherSpeed);
   }
 
-  public CommandBase spoolUpLauncherCommand() {
+  public void spoolUpLauncher() {
     // Inline construction of command goes here.
     // Subsystem::RunOnce implicitly requires `this` subsystem.
-    return runOnce(
-        () -> {
-          /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the operator spool up the launcher */
-          //   leftMotor.set(launcherSpeed);
-          //   rightMotor.set(launcherSpeed);
-        });
+    // return runOnce(
+    //     () -> {
+    //       /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the
+    // operator spool up the launcher */
+    //       //   leftMotor.set(launcherSpeed);
+    //       //   rightMotor.set(launcherSpeed);
+    //     });
+    Timer timer = new Timer();
+    timer.reset();
+    stopLauncher();
+    double currentSpeed = 0.0;
+
+    while (currentSpeed < launcherSpeed) {
+      timer.start();
+      while (timer.get() < 0.1) {
+        // wait
+      }
+      timer.stop();
+      timer.reset();
+      currentSpeed += 0.1;
+      leftMotor.set(currentSpeed);
+      rightMotor.set(currentSpeed);
+    }
+  }
+
+  public void stopLauncher() {
+    leftMotor.stopMotor();
+    rightMotor.stopMotor();
   }
 
   public void increaseLauncherSpeed() {
     if (launcherSpeed < 1.0) {
       launcherSpeed += 0.1;
+      // leftMotor.set(launcherSpeed);
+      // rightMotor.set(launcherSpeed);
     }
   }
 
   public void decreaseLauncherSpeed() {
     if (launcherSpeed > 0.1) {
       launcherSpeed -= 0.1;
+      // leftMotor.set(launcherSpeed);
+      // rightMotor.set(launcherSpeed);
     }
   }
 

--- a/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
+++ b/Small_Robot/src/main/java/frc/robot/subsystems/LauncherSubsystem.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
@@ -9,6 +10,7 @@ public class LauncherSubsystem extends SubsystemBase {
   //   private MecanumDrive m_robotDrive;
   private PWMSparkMax leftMotor;
   private PWMSparkMax rightMotor;
+  private double launcherSpeed;
 
   public LauncherSubsystem() {
     leftMotor = new PWMSparkMax(5);
@@ -16,9 +18,11 @@ public class LauncherSubsystem extends SubsystemBase {
 
     rightMotor.setInverted(true);
 
+    launcherSpeed = 0.20;
+
     /* commented out because we don't want to spool up the launcher on initialization */
-    // leftMotor.set(0.25);
-    // rightMotor.set(0.25);
+    // leftMotor.set(launcherSpeed);
+    // rightMotor.set(launcherSpeed);
   }
 
   public CommandBase spoolUpLauncherCommand() {
@@ -27,13 +31,30 @@ public class LauncherSubsystem extends SubsystemBase {
     return runOnce(
         () -> {
           /* at time of writing, the launcher broke; so, for now, we DO NOT want to let the operator spool up the launcher */
-          //   leftMotor.set(0.25);
-          //   rightMotor.set(0.25);
+          //   leftMotor.set(launcherSpeed);
+          //   rightMotor.set(launcherSpeed);
         });
+  }
+
+  public void increaseLauncherSpeed() {
+    if (launcherSpeed < 1.0) {
+      launcherSpeed += 0.1;
+    }
+  }
+
+  public void decreaseLauncherSpeed() {
+    if (launcherSpeed > 0.1) {
+      launcherSpeed -= 0.1;
+    }
   }
 
   public void stop() {
     leftMotor.stopMotor();
     rightMotor.stopMotor();
+  }
+
+  @Override
+  public void periodic() {
+    SmartDashboard.putNumber("Launcher Speed:", launcherSpeed);
   }
 }


### PR DESCRIPTION
- updated CameraSubsystem to support selecting a desired target; this desired target will be used when triggering the GoToSpecificTargetCommand
- desired target will be displayed to Dashboard
- desired target can be incremented (right bumper) and decremented (left bumper) to values 1 thru 3, inclusive
- added speed selection to launcher subsystem
- speed selection for launcher subsystem can now be increased or decreased by 0.1 increments using d-pad up and d-pad down (range 0.1 thru 1.0, inclusive)